### PR TITLE
Fixed unicode incompatibility

### DIFF
--- a/cmsplugin_raw_html/models.py
+++ b/cmsplugin_raw_html/models.py
@@ -1,10 +1,12 @@
 from cms.models import CMSPlugin
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class RawHtmlPlugin(CMSPlugin):
 
     body = models.TextField('HTML')
 
-    def __unicode__(self):
-        return str(self.body)
+    def __str__(self):
+        return self.body


### PR DESCRIPTION
For words in other languages like Spanish with non-ascii characters like áéíóúñ .
